### PR TITLE
HelpWindowTest: fix bogus "focus on another stage" code

### DIFF
--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -60,7 +60,11 @@ public class HelpWindowTest extends GuiUnitTest {
         guiRobot.interact(helpWindow::show);
 
         // Focus on another stage to remove focus from the helpWindow
-        FxToolkit.setupStage(Stage::requestFocus);
+        guiRobot.interact(() -> {
+            Stage temporaryStage = new Stage();
+            temporaryStage.show();
+            temporaryStage.requestFocus();
+        });
         assertFalse(helpWindow.getRoot().isFocused());
 
         guiRobot.interact(helpWindow::focus);


### PR DESCRIPTION
When run in head-full mode, HelpWindowTest fails with the following
exception:

    seedu.address.ui.HelpWindowTest > focus_helpWindowNotFocused_focused FAILED
        java.lang.AssertionError at HelpWindowTest.java:64

The line in question is from the following:

    assertFalse(helpWindow.getRoot().isFocused());

which comes right after:

    // Focus on another stage to remove focus from the helpWindow
    FxToolkit.setupStage(Stage::requestFocus);

However, despite what the comment claims, the call to
FxToolkit.setupStage(...) does not "focus on another stage". This is
because the Stage registered with TestFX is the HelpWindow stage itself.
In other words, we are just requesting the HelpWindow to focus itself,
which is the complete opposite of "removing focus from the helpWindow".

This "focus on another stage" code was written in 1c6071fa
(HelpWindowTest: fix failing test in non-headless mode, 2018-04-16). At
that point in time, the stage registered with TestFX _was_ "another
stage"[1] and so the code was correct. However, in a42ededd (Fix
stalling HelpWindowTest, 2018-06-26) this was changed such that the
stage registered with TestFX is the HelpWindow stage itself. Yet, the
code was not modified to properly operate in the new world order[2].

Fix this piece of code by creating a temporary stage to focus on, so
that the goal of "removing focus from the helpWindow" is properly
achieved.

[1]: Somewhat-ish. The full story can be found in a42ededd (Fix stalling
     HelpWindowTest, 2018-06-26).

[2]: And obviously, the author did not run tests in head-full mode :-S